### PR TITLE
Optimization: Actually use move constructors and avoid copy

### DIFF
--- a/hermitianMatrix.h
+++ b/hermitianMatrix.h
@@ -21,7 +21,7 @@ class HermitianMatrix : public SquareMatrix<std::complex<double>>
         //True if we eigenvalues of the hamiltonian have been computed.
         bool loadedEigenVectors = false;
     public:
-        HermitianMatrix(const SquareMatrix<std::complex<double>>&& mat) : SquareMatrix<std::complex<double>>(mat), eigenValues(mat.getDim()) {};
+        HermitianMatrix(SquareMatrix<std::complex<double>>&& mat) : SquareMatrix<std::complex<double>>(std::move(mat)), eigenValues(getDim()) {};
         explicit HermitianMatrix(std::size_t dim) : SquareMatrix<std::complex<double>>(dim), eigenValues(dim)
         {};
         /**

--- a/main.cpp
+++ b/main.cpp
@@ -60,22 +60,24 @@ int main(int argc, char **argv){
     Timer timer{};
 
     // Add the Interaction with external magnetic field:
+    HermitianMatrix interaction = identity;
     for(size_t i = 0; i < N; i++){
-        HermitianMatrix interaction = i == 0 ? sigmaZ : identity;
+        interaction = i == 0 ? sigmaZ : identity;
         for(size_t j = 1; j < N; j++){
             interaction = tens_product(interaction, ((j == i) ? sigmaZ : identity));
         }
-        H += interaction* static_cast<std::complex<double>>(lambda);
+        interaction*= static_cast<std::complex<double>>(lambda);
+        H += interaction;
     }
     // Add the Interaction among nearest neighbor spins:
     for(size_t i = 0; i < N-1; i++){
-        HermitianMatrix interaction = i == 0 ? sigmaX : identity;
+        interaction = i == 0 ? sigmaX : identity;
         for(size_t j = 1; j < N; j++){    
             interaction = tens_product(interaction, ((j == i || j == i+1) ? sigmaX : identity)); 
         }
         H += interaction;
     }
-    std::cerr << "Hamiltonian has been built, diagonalizing:" << std::endl;
+    std::cerr << "Hamiltonian has been built, diagonalizing: "  << timer.elapsed() << std::endl;
     // Find and print the spectrum
     H.findSpectrumAlg2('N');
     for(auto& E : H.getEigenValues()){

--- a/matrix.h
+++ b/matrix.h
@@ -36,7 +36,6 @@ class Matrix{
 
     public:
         explicit Matrix(std::size_t nRows, std::size_t nColumns);
-        Matrix(const Matrix<T>& m1) = default;
 
         friend std::ostream& operator<< <> (std::ostream& o,const Matrix<T>& m);
         std::size_t getDimX() const {return nRows;};
@@ -203,8 +202,8 @@ template<typename T>
 class SquareMatrix : public Matrix<T>{
     public:
         explicit SquareMatrix(std::size_t size) : Matrix<T>(size, size){};
-        SquareMatrix(const Matrix<T>&& m) : Matrix<T>(m) {
-            assert(m.getDimX() == m.getDimY() && "Matrix is not a square amtrix");
+        SquareMatrix(Matrix<T>&& m) : Matrix<T>(std::move(m)) {
+            assert(getDimX() == getDimY() && "Matrix is not a square matrix");
         }
         size_t getDim() const { return getDimX();}
         // Returns the trace of the matrix


### PR DESCRIPTION
After performing some profiling with valgrind I found out that move constructors were not being used and everything was copied there were three main reasons for that:

- `rvalue` reference variables are `lvalue` so I needed to call `std::move` in constructors
- For the class `Matrix<T>` the move constructor was not even created by deafult due to the line `Matrix(const Matrix<T>& m1) = default;`
- In `HermitianMatrix(const SquareMatrix<std::complex<double>>&& mat) : SquareMatrix<std::complex<double>>(mat), eigenValues(mat.getDim()) {};` mat was taken as const, so it was not calling move constructor of `SquareMatrix`

Overall this is a great improvement in speed: for N=13 program time decreased from `~100s` to `~80s`